### PR TITLE
Fix the checkpoint saving issues when zero3 is enabled

### DIFF
--- a/chatllms/utils/model_utils.py
+++ b/chatllms/utils/model_utils.py
@@ -309,17 +309,20 @@ def get_logits_processor() -> LogitsProcessorList:
     return logits_processor
 
 
+
 def safe_save_model_for_hf_trainer(trainer: Trainer, output_dir: str):
     """Collects the state dict and dump to disk."""
-    state_dict = trainer.model.state_dict()
-    if not is_deepspeed_zero3_enabled() and trainer.args.should_save:
-        cpu_state_dict = {
-            key: value.cpu()
-            for key, value in state_dict.items()
-        }
-        del state_dict
-        trainer._save(output_dir, state_dict=cpu_state_dict)  # noqa
-    elif is_deepspeed_zero3_enabled():
-        # save for deepspeed ZeRO3 checkpoint
-        if not trainer.wrapped_model.save_16bit_model(output_dir):
-            trainer.wrapped_model.save_checkpoint(output_dir, save_latest=True)
+    trainer.save_model(output_dir)
+
+    # state_dict = trainer.model.state_dict()
+    # if not is_deepspeed_zero3_enabled() and trainer.args.should_save:
+    #     cpu_state_dict = {
+    #         key: value.cpu()
+    #         for key, value in state_dict.items()
+    #     }
+    #     del state_dict
+    #     trainer._save(output_dir, state_dict=cpu_state_dict)  # noqa
+    # elif is_deepspeed_zero3_enabled():
+    #     # save for deepspeed ZeRO3 checkpoint
+    #     if not trainer.wrapped_model.save_16bit_model(output_dir):
+    #         trainer.wrapped_model.save_checkpoint(output_dir, save_latest=True)


### PR DESCRIPTION
Hi, I change the ckpt saving behavior by calling the `save_model` interface of official Trainer from hf-transformers, since this function will handle the case under different training framework including deepspeed zero3, where the model will be saved as pytorch.bin model for deepspeed (in old version of transformers) or collected state_dict (in new version of transformers)